### PR TITLE
fix(stratumdifficulty): increase from bitaxe default 1000 to 5000

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -44,7 +44,7 @@ menu "Stratum Configuration"
     config STRATUM_DIFFICULTY
         int "Stratum default difficulty"
         range 0 4294967296
-        default 1000
+        default 5000
         help
             A starting difficulty to use with the pool.
 


### PR DESCRIPTION
This PR increases the default Stratum difficulty from 1000 to 5000 to better suit the NerdQAxe’s higher hashrate.

With the current default of 1000, the NerdQAxe submits shares about once per second, which is unnecessarily frequent and leads to excessive share traffic. In testing (and based on pool operator feedback), a starting diff of 5000 aligns more closely with the device’s hashrate, producing shares roughly every 3–4 seconds.